### PR TITLE
#4-v-uno-tratamento-erro-falha-services-apache

### DIFF
--- a/src/apache.rs
+++ b/src/apache.rs
@@ -19,6 +19,11 @@ pub fn monitor_apache_config(hostname: &str, apache_config_file: &str) {
 fn add_config_line_to_apache(hostname: &str, apache_config_file: &str) {
     let config_line = format!("ServerName {}", hostname);
     
+    if !std::path::Path::new(apache_config_file).exists() {
+        log_message(&format!("Arquivo de configuração do Apache não encontrado: {}. Verifique se o caminho está correto e o arquivo existe.", apache_config_file));
+        return;
+    }
+
     let config_content = std::fs::read_to_string(apache_config_file).expect(ERR_LER_ARQUIVO);
     
     if !config_content.contains(&config_line) {

--- a/src/services.rs
+++ b/src/services.rs
@@ -2,15 +2,24 @@ use crate::utils::log_message;
 use std::process::Command;
 
 pub const SERVICES: &[&str] = &["apache2", "dovecot", "postfix", "clamav-daemon"];
-pub const MSG_SERVICO_PARADO: &str = "Serviço {} está parado. Reiniciando...";
-pub const MSG_SERVICO_REINICIADO: &str = "Serviço {} reiniciado com sucesso.";
-pub const MSG_SERVICO_FALHA_REINICIAR: &str = "Falha ao reiniciar o serviço {}.";
-pub const MSG_SERVICO_EXECUTANDO: &str = "Serviço {} está em execução.";
 pub const ERR_VERIFICAR_SERVICO: &str = "Falha ao verificar o serviço.";
 pub const ERR_REINICIAR_SERVICO: &str = "Falha ao reiniciar o serviço.";
 
+fn service_exists(service: &str) -> bool {
+    Command::new("systemctl")
+        .arg("status")
+        .arg(service)
+        .output()
+        .map_or(false, |output| output.status.success())
+}
+
 pub fn check_and_restart_services() {
     for &service in SERVICES {
+        if !service_exists(service) {
+            log_message(&format!("Serviço {} não encontrado.", service));
+            continue;
+        }
+
         let status = Command::new("systemctl")
             .arg("is-active")
             .arg("--quiet")
@@ -19,7 +28,7 @@ pub fn check_and_restart_services() {
             .expect(ERR_VERIFICAR_SERVICO);
         
         if !status.success() {
-            log_message(&format!("{} {}", MSG_SERVICO_PARADO, service));
+            log_message(&format!("Serviço {} está parado. Reiniciando...", service));
             let restart = Command::new("systemctl")
                 .arg("restart")
                 .arg(service)
@@ -27,12 +36,12 @@ pub fn check_and_restart_services() {
                 .expect(ERR_REINICIAR_SERVICO);
             
             if restart.success() {
-                log_message(&format!("{} {}", MSG_SERVICO_REINICIADO, service));
+                log_message(&format!("Serviço {} reiniciado com sucesso.", service));
             } else {
-                log_message(&format!("{} {}", MSG_SERVICO_FALHA_REINICIAR, service));
+                log_message(&format!("Falha ao reiniciar o serviço {}.", service));
             }
         } else {
-            log_message(&format!("{} {}", MSG_SERVICO_EXECUTANDO, service));
+            log_message(&format!("Serviço {} está em execução.", service));
         }
     }
 }


### PR DESCRIPTION
Adicionar verificações para garantir que o arquivo exista antes de tentar lê-lo:

Verificar se o caminho do arquivo de configuração do Apache (apache_config_file) está correto e se o arquivo realmente existe. O caminho padrão usado é /etc/apache2/apache2.conf, mas pode ser diferente dependendo da configuração.

Garantir que o código não tente reiniciar serviços inexistentes, verificar se o serviço existe antes de tentar reiniciá-lo.

Garantir que o caminho do arquivo de configuração do Apache esteja correto e que o arquivo exista. Se o arquivo não existir, adicione uma verificação para garantir que ele não falhe silenciosamente.

Garantir que o log informe quando um serviço não é encontrado e continue a verificar os outros serviços.